### PR TITLE
Add Flask API and Gradio UI with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 7860 5000
+CMD ["bash", "start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # HuggingFace-NLP
-Ce projet met en œuvre des modèles Transformer via l'écosystème Hugging Face pour des tâches de Traitement Automatique du Langage Naturel.  Il couvre la classification de sentiment , la génération de texte, le question-réponse , ainsi que l'analyse comparative de différents modèles. 
+Ce projet met en œuvre des modèles Transformer via l'écosystème Hugging Face pour des tâches de Traitement Automatique du Langage Naturel.  Il couvre la classification de sentiment , la génération de texte, le question-réponse , ainsi que l'analyse comparative de différents modèles.
+
+## Démarrage rapide
+
+Construisez l'image Docker et lancez-la :
+
+```bash
+docker build -t hf-nlp-demo .
+docker run -p 5000:5000 -p 7860:7860 hf-nlp-demo
+```
+
+La partie API est disponible sur `http://localhost:5000` et l'interface Gradio sur `http://localhost:7860`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,26 @@
+from flask import Flask, request, jsonify
+from transformers import pipeline
+
+app = Flask(__name__)
+
+# Initialize models
+classifier = pipeline("sentiment-analysis")
+qa_model = pipeline("question-answering")
+
+@app.route("/classify", methods=["POST"])
+def classify():
+    data = request.get_json(force=True)
+    text = data.get("text", "")
+    results = classifier(text)
+    return jsonify(results)
+
+@app.route("/answer", methods=["POST"])
+def answer():
+    data = request.get_json(force=True)
+    question = data.get("question", "")
+    context = data.get("context", "")
+    result = qa_model(question=question, context=context)
+    return jsonify(result)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/gradio_frontend.py
+++ b/gradio_frontend.py
@@ -1,0 +1,38 @@
+import gradio as gr
+import requests
+
+API_URL = "http://localhost:5000"
+
+
+def classify_text(text):
+    response = requests.post(f"{API_URL}/classify", json={"text": text})
+    if response.ok:
+        data = response.json()
+        return data[0]["label"]
+    return "Error"
+
+
+def answer_question(context, question):
+    response = requests.post(f"{API_URL}/answer", json={"context": context, "question": question})
+    if response.ok:
+        data = response.json()
+        return data.get("answer", "")
+    return "Error"
+
+
+with gr.Blocks() as demo:
+    gr.Markdown("# NLP Demo")
+    with gr.Tab("Classification"):
+        inp = gr.Textbox(label="Text")
+        out = gr.Textbox(label="Label")
+        btn = gr.Button("Classify")
+        btn.click(classify_text, inputs=inp, outputs=out)
+    with gr.Tab("Question Answering"):
+        ctx = gr.Textbox(label="Context")
+        ques = gr.Textbox(label="Question")
+        out_ans = gr.Textbox(label="Answer")
+        btn2 = gr.Button("Answer")
+        btn2.click(answer_question, inputs=[ctx, ques], outputs=out_ans)
+
+
+demo.launch(server_name="0.0.0.0")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+gradio
+transformers
+torch
+requests

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+python app.py &
+python gradio_frontend.py


### PR DESCRIPTION
## Summary
- implement `app.py` Flask backend for classification and QA
- implement `gradio_frontend.py` UI calling the API
- add a simple startup script and Dockerfile
- document Docker usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab859d85c8321bcb6b8cb42ca4937